### PR TITLE
Added loopback filesystem support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/test/support/Gemfile.lock
+/tmp

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ For the zones:
     iptype            - "shared" (default) or "exclusive".
     nets              - Array of network interfaces to add.  Interfaces must be in the format of "address:physical(:defrouter)
     datasets          - Array of datasets to include on this zone.
+    loopbacks         - Array of loopback file systems to export from global to this zone
     inherits          - Array of inherit-pkg-dir directories. These cannot be changed after the zone is installed. Defaults to [ "/lib", "/platform", "/sbin", "/usr" ].
     password          - Root password for the zone, to put in /etc/sysidcfg.  Must be encyrpted with crypt.
     use_sysidcfg      - Whether or not to create a sysidcfg file. Defaults to true.
@@ -68,15 +69,16 @@ Usage
       nets [ "192.168.0.2/24:e1000g0:192.168.0.1" ]
       inherits ["/lib", "/bin", "/opt"]
     end
-  
+
     zone "test2" do
       action :start
       clone "test"
       autoboot "false"
       path "/zones/test2"
       datasets [ "zones/test/mysql_data" ]
+      loopbacks [ "/shared" ]
     end
-  
+
 
 ### Actions
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,6 @@ maintainer_email "marthag@wix.com"
 license          "Apache 2.0"
 description      "Installs/Configures Solaris zones"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.6"
+version          "0.0.7"
 
 supports "solaris2"

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -8,6 +8,7 @@ attribute :limitpriv, :kind_of => String, :default => nil
 attribute :iptype, :kind_of => String, :equal_to => [ "shared", "exclusive"], :default => "shared"
 attribute :nets, :kind_of => Array, :default => []
 attribute :datasets, :kind_of => Array, :default => []
+attribute :loopbacks, :kind_of => Array, :default => []
 attribute :inherits, :kind_of => Array, :default => [ "/lib", "/platform", "/sbin", "/usr" ]
 attribute :password, :kind_of => String
 attribute :use_sysidcfg, :kind_of => [TrueClass, FalseClass], :default => true

--- a/templates/default/sysidcfg.erb
+++ b/templates/default/sysidcfg.erb
@@ -1,14 +1,14 @@
 system_locale=C
-timezone=<%= node[:zone][:timezone] %>
+timezone=<%= node['zone']['timezone'] %>
 terminal=xterms
 security_policy=NONE
 root_password=<%= @zone.password %>
-timeserver=<%= node[:zone][:timeserver] %>
-name_service=DNS {domain_name=<%= node[:domain] %>
-       name_server=<%= node[:zone][:dns_servers].join(',') %>}
-network_interface=primary { hostname=<%= @zone.name %>.<%= node[:domain] %>
+timeserver=<%= node['zone']['timeserver'] %>
+name_service=DNS {domain_name=<%= node['domain'] %>
+       name_server=<%= node['zone']['dns_servers'].join(',') %>}
+network_interface=primary { hostname=<%= @zone.name %>.<%= node['domain'] %>
        ip_address=<%= @zone.desired_props["net"].first.split(/:|\//).first %>
-       netmask=<%= node[:network][:interfaces][@zone.desired_props["net"].first.split(':')[1]][:addresses][node[:network][:interfaces][@zone.desired_props["net"].first.split(':')[1]][:addresses].to_hash.keys.select{|k| k =~ /\d+.\d+.\d+.\d+/}.first][:netmask] %>
+       netmask=<%= node['network']['interfaces'][@zone.desired_props["net"].first.split(':')[1]]['addresses'][node['network']['interfaces'][@zone.desired_props["net"].first.split(':')[1]]['addresses'].to_hash.keys.select{|k| k =~ /\d+.\d+.\d+.\d+/}.first]['netmask'] %>
        protocol_ipv6=no
-       default_route=<%= node[:network][:default_gateway] %>}
+       default_route=<%= node['network']['default_gateway'] %>}
 nfs4_domain=dynamic

--- a/templates/default/sysidcfg_nodns.erb
+++ b/templates/default/sysidcfg_nodns.erb
@@ -1,13 +1,13 @@
 system_locale=C
-timezone=<%= node[:zone][:timezone] %>
+timezone=<%= node['zone']['timezone'] %>
 terminal=xterms
 security_policy=NONE
 root_password=<%= @zone.password %>
-timeserver=<%= node[:zone][:timeserver] %>
+timeserver=<%= node['zone']['timeserver'] %>
 name_service=NONE
-network_interface=primary { hostname=<%= @zone.name %>.<%= node[:domain] %>
+network_interface=primary { hostname=<%= @zone.name %>.<%= node['domain'] %>
        ip_address=<%= @zone.desired_props["net"].first.split(/:|\//).first %>
-       netmask=<%= node[:network][:interfaces][@zone.desired_props["net"].first.split(':')[1]][:addresses][node[:network][:interfaces][@zone.desired_props["net"].first.split(':')[1]][:addresses].to_hash.keys.select{|k| k =~ /\d+.\d+.\d+.\d+/}.first][:netmask] %>
+       netmask=<%= node['network']['interfaces'][@zone.desired_props["net"].first.split(':')[1]]['addresses'][node['network']['interfaces'][@zone.desired_props["net"].first.split(':')[1]]['addresses'].to_hash.keys.select{|k| k =~ /\d+.\d+.\d+.\d+/}.first]['netmask'] %>
        protocol_ipv6=no
-       default_route=<%= node[:network][:default_gateway] %>}
+       default_route=<%= node['network']['default_gateway'] %>}
 nfs4_domain=dynamic


### PR DESCRIPTION
We make use of read-only file system exports from the global zone to distribute binaries and configs to the guests. This patch allows for that with a "loopbacks" array.
